### PR TITLE
Add the Atmel pin names to the mapping table

### DIFF
--- a/doc/ATtiny48_88_pin_map.txt
+++ b/doc/ATtiny48_88_pin_map.txt
@@ -1,30 +1,30 @@
-Pin | Role
-----+------
-1   | RESET
-2   | OD0
-3   | OD1
-4   | OD2
-5   | OD3
-6   | OD4
-7   | VCC
-8   | GND
-9   | PP6
-10  | PP7
-11  | OD5
-12  | OD6
-13  | OD7
-14  | PP0
-15  | PP1
-16  | PP2
-17  | PP3
-18  | PP4
-19  | PP5
-20  | VCC
-21  | INT
-22  | GND
-23  | AD0
-24  | AD1
-25  | N/C
-26  | N/C
-27  | SDA
-28  | SCL
+PDIP28 Pin | Name    | Role
+-----------+---------+------
+1          |  PC6    | RESET
+2          |  PD0    | OD0
+3          |  PD1    | OD1
+4          |  PD2    | OD2
+5          |  PD3    | OD3
+6          |  PD4    | OD4
+7          |  VCC    | VCC
+8          |  GND    | GND
+9          |  PB6    | PP6
+10         |  PB7    | PP7
+11         |  PD5    | OD5
+12         |  PD6    | OD6
+13         |  PD7    | OD7
+14         |  PB0    | PP0
+15         |  PB1    | PP1
+16         |  PB2    | PP2
+17         |  PB3    | PP3
+18         |  PB4    | PP4
+19         |  PB5    | PP5
+20         |  AVCC   | VCC
+21         |  PC7    | INT
+22         |  GND    | GND
+23         |  PC0    | AD0
+24         |  PC1    | AD1
+25         |  PC2    | N/C
+26         |  PC3    | N/C
+27         |  PC4    | SDA
+28         |  PC5    | SCL


### PR DESCRIPTION
Since the ATtiny 48/88 come in a variety of packages with different pin numberings, add the Atmel pin designators for ease of layout
